### PR TITLE
Fix some puppet lint errors

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -7,15 +7,15 @@
 # [*auth_type*] Auth type.
 #   Optional. none or 'cephx'. Defaults to 'cephx'.
 #
-# [*signatures_require*] If Ceph requires signatures on all 
+# [*signatures_require*] If Ceph requires signatures on all
 #   message traffic (client<->cluster and between cluster daemons).
 #   Optional. Boolean.
 #
-# [*signatures_cluster*] If Ceph requires signatures on all 
+# [*signatures_cluster*] If Ceph requires signatures on all
 #   message traffic between the cluster daemons.
 #   Optional. Boolean.
 #
-# [*signatures_service*] If Ceph requires signatures on all 
+# [*signatures_service*] If Ceph requires signatures on all
 #   message traffic between clients and the cluster.
 #   Optional. Boolean.
 #
@@ -34,16 +34,16 @@
 # [*pool_default_min_size*] The default minimum num of replicas.
 #   Optional. Integer
 #
-# [*pool_default_crush_rule*] The default CRUSH ruleset to use 
+# [*pool_default_crush_rule*] The default CRUSH ruleset to use
 #   when creating a pool.
 #   Optional. Integer
 #
-# [*mon_osd_full_ratio*] Percentage of disk space used before 
-#   an OSD considered full 
+# [*mon_osd_full_ratio*] Percentage of disk space used before
+#   an OSD considered full
 #   Optional. Integer e.g. 95, NOTE: ends in config as .95
 #
-# [*mon_osd_nearfull_ratio*] Percentage of disk space used before 
-#   an OSD considered nearfull 
+# [*mon_osd_nearfull_ratio*] Percentage of disk space used before
+#   an OSD considered nearfull
 #   Optional. Float e.g. 90, NOTE: ends in config as .90
 #
 # [*journal_size_mb*] The size of the journal in megabytes.
@@ -56,7 +56,7 @@
 #   Optional. {public-network-ip/netmask}
 #
 # [*mon_data*] The monitor’s data location.
-#   Optional. Defaults to '/var/lib/ceph/mon/mon.$id'. 
+#   Optional. Defaults to '/var/lib/ceph/mon/mon.$id'.
 #
 # [*mon_init_members*] The IDs of initial MONs in the cluster during startup.
 #   Optional. String like e.g. 'a, b, c'.
@@ -71,13 +71,13 @@
 #   Optional. Defaults to 'xfs'.
 #
 # [*osd_mkfs_options*] The options used to format the OSD fs.
-#   Optional. Defaults to '-f' for XFS. 
+#   Optional. Defaults to '-f' for XFS.
 #
 # [*osd_mount_options*] The options used to mount the OSD fs.
 #   Optional. Defaults to 'rw,noatime,inode64' for XFS.
 #
 # [*mds_activate*] Switch to activate the '[mds]' section in the config.
-#   Optional. Defaults to 'true'. 
+#   Optional. Defaults to 'true'.
 #
 # [*mds_data*] The path to the MDS data.
 #   Optional. Defaults to '/var/lib/ceph/mds/mds.$id'

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -85,16 +85,16 @@ define ceph::key (
 
   # to concat the capability settings
   if $cap_mon {
-    $mon_caps += "--cap mon '${cap_mon}' "
+    $mon_caps = "--cap mon '${cap_mon}' "
   }
   if $cap_osd {
-    $osd_caps += "--cap osd '${cap_osd}' "
+    $osd_caps = "--cap osd '${cap_osd}' "
   }
   if $cap_mds {
-    $mds_caps += "--cap mds '${cap_mds}' "
+    $mds_caps = "--cap mds '${cap_mds}' "
   }
 
-  $concat_caps = "$mon_caps$osd_caps$mds_caps"
+  $concat_caps = "${mon_caps}${osd_caps}${mds_caps}"
 
   # generate the keyring file
   exec { "ceph-key-${name}":
@@ -105,7 +105,7 @@ define ceph::key (
 
   # set the correct mask for the keyring file
   # TODO: make sure the user/group exists
-  file { "${keyring_path}":
+  file { $keyring_path:
     ensure  => file,
     owner   => $user,
     group   => $group,
@@ -117,7 +117,7 @@ define ceph::key (
     exec { "ceph-inject-key-${name}":
       command => "ceph --name '${inject_as_id}' --keyring '${$inject_keyring}' auth add '${name}' --in-file='${keyring_path}'",
       onlyif  => "ceph --name '${inject_as_id}' --keyring '${$inject_keyring}' -s",
-      require => [ Package['ceph'], File["${keyring_path}"] ]
+      require => [ Package['ceph'], File[$keyring_path] ]
     }
   }
 

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -100,7 +100,7 @@ define ceph::key (
   exec { "ceph-key-${name}":
     command => "ceph-authtool ${keyring_path} --create-keyring --name='${name}' --add-key='${secret}' ${concat_caps}",
     creates => $keyring_path,
-    require => Package['ceph'],
+    require => Package['ceph-common'],
   }
 
   # set the correct mask for the keyring file

--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -51,14 +51,14 @@ define ceph::osd::device (
     $osd_id_fact = "ceph_osd_id_${devname}1"
     $mkfs_require = [Package['xfsprogs'], Exec["mkpart_${devname}"]]
   } else {
-    $dev_path = "${name}"
+    $dev_path = $name
     $blkid_uuid_fact = "blkid_uuid_${devname}"
     $osd_id_fact = "ceph_osd_id_${devname}"
     $mkfs_require = [Package['xfsprogs']]
   }
 
   # TODO: add other file systems ... otherwise fail!
-  if $::ceph::conf::osd_mkfs_type == "xfs" {
+  if $::ceph::conf::osd_mkfs_type == 'xfs' {
     exec { "mkfs_${devname}":
       command => "mkfs.xfs ${::ceph::conf::osd_mkfs_options} ${dev_path}",
       unless  => "xfs_admin -l ${dev_path}",
@@ -67,14 +67,14 @@ define ceph::osd::device (
   }
 
   $tmp_blkid = inline_template('<%= scope.lookupvar(blkid_uuid_fact) or "undefined" %>')
-  
+
   if $tmp_blkid == 'undefined' {
     $osd_conf_id_fact = regsubst($osd_id_fact, 'ceph_osd_id', 'ceph_osd_conf_id')
     $osd_conf_id = inline_template('<%= scope.lookupvar(osd_conf_id_fact) or "undefined" %>')
     $uuid_conf_fact = "ceph_osd_conf_uuids_osd.${osd_conf_id}"
     $blkid = inline_template('<%= scope.lookupvar(uuid_conf_fact) or "undefined" %>')
   } else {
-    $blkid = "${tmp_blkid}"
+    $blkid = $tmp_blkid
   }
 
   if $blkid == 'undefined' {
@@ -86,7 +86,7 @@ define ceph::osd::device (
     }
 
     exec { "ceph_osd_create_${devname}":
-      path    => "/usr/sbin:/usr/bin:/sbin:/bin:",
+      path    => '/usr/sbin:/usr/bin:/sbin:/bin:',
       command => "ceph osd create `cat /var/lib/ceph/tmp/${blkid_file}`",
       unless  => "ceph osd dump | grep -sq `cat /var/lib/ceph/tmp/${blkid_file}`",
       require => [Ceph::Key['client.admin'], Exec["get_blkid_${devname}"]],
@@ -103,9 +103,9 @@ define ceph::osd::device (
   $tmp_osd_id = inline_template('<%= scope.lookupvar(osd_id_fact) or "undefined" %>')
 
   if $tmp_osd_id == 'undefined' {
-     $osd_id = "${osd_conf_id}"
+    $osd_id = $osd_conf_id
   } else {
-     $osd_id = "${tmp_osd_id}"
+    $osd_id = $tmp_osd_id
   }
 
   if $blkid != 'undefined'  and defined( Ceph::Key['client.admin'] ){

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -24,6 +24,10 @@ class ceph::package (
     ensure => $package_ensure
   }
 
+  package { 'ceph-common':
+    ensure => $package_ensure
+  }
+
   #FIXME: Ensure ceph user/group
 
   file { '/var/lib/ceph':


### PR DESCRIPTION
Received bug report from David Moreau Simard moi@dmsimard.com about the rc/eisbrecher code state showing the following error before compiling the catalog with puppet 3.3.x:

_Error: Could not retrieve catalog from remote server: Could not intern from text/pson: Could not convert from pson: Could not find relationship target "Ceph::Conf::Osd[]"_

These commits fixed it for David and may affect also our setup. Cherry-picked them from https://github.com/dalgaaf/puppet-ceph/tree/feature/wip-da-rework-and-simplify. These make also Travis CI pass again.

This contains also a small change to make sure the ceph-common package get installed where ceph-authtool is needed (7138009).
