### PR TITLE
Travis: extend tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 rvm:
   - 1.8.7
   - 1.9.3
+  - 2.0.0
 notifications:
   email:
     - <your email address>
@@ -9,3 +10,14 @@ env:
   - PUPPET_VERSION=3.0.2
   - PUPPET_VERSION=3.1.1
   - PUPPET_VERSION=3.2.1
+  - PUPPET_VERSION=3.2.4
+  - PUPPET_VERSION=3.3.0
+matrix:
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_VERSION=2.7.21
+    - rvm: 2.0.0
+      env: PUPPET_VERSION=3.0.2
+    - rvm: 2.0.0
+      env: PUPPET_VERSION=3.1.1
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,9 @@
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
 
-task :default => [:spec]
-#task :default => [:spec, :lint]
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_autoloader_layout')
+PuppetLint.configuration.send('disable_class_parameter_defaults')
+
+#task :default => [:spec]
+task :default => [:spec, :lint]

--- a/manifests/rgw_user.pp
+++ b/manifests/rgw_user.pp
@@ -29,8 +29,8 @@
 
 
 class ceph::rgw_user (
-  $user = "admin",
-  $key  = "--gen-secret",
+  $user = 'admin',
+  $key  = '--gen-secret',
   $swift_user = undef,
   $swift_key  = '--gen-secret',
 ) {
@@ -44,24 +44,24 @@ class ceph::rgw_user (
     command => "radosgw-admin user create --uid=${user} \
  ${key_opt} --display-name ${user}",
     require => Service['radosgw'],
-    unless  => "radosgw-admin user info --uid=admin"
+    unless  => 'radosgw-admin user info --uid=admin'
   }
 
   if (swift_user){
 
-     if $swift_key != '--gen-secret'{
-       $swift_key_opt = "--secret ${swift_key}"
-     } else{
-       $swift_key_opt = $swift_key
-     }
+    if $swift_key != '--gen-secret'{
+      $swift_key_opt = "--secret ${swift_key}"
+    } else{
+      $swift_key_opt = $swift_key
+    }
 
-     exec { 'add-swift-subuser':
-       command => "radosgw-admin subuser create \
+    exec { 'add-swift-subuser':
+      command => "radosgw-admin subuser create \
 --uid=${user} --subuser=${swift_user} \
 ${swift_key_opt} --display-name ${swift_user} \
 --key-type swift --access=full",
-       require => Exec['add-user'] ,
-       unless  => "radosgw-admin user info --uid=admin|grep admin:${swift_user}"
-     }
+      require => Exec['add-user'] ,
+      unless  => "radosgw-admin user info --uid=admin|grep admin:${swift_user}"
+    }
   }
 }


### PR DESCRIPTION
Extended tests:
- run puppet-lint, disabled some checks for now:
  - disable_80chars
  - disable_autoloader_layout
  - disable_class_parameter_defaults
- test also rvm 2.0.0 but ignore some puppet versions for this case:
  - 2.7.21
  - 3.0.2
  - 3.1.1
- add some more puppet versions to be tested (3.2.4, 3.3.0)

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
(cherry picked from commit c2ffe6f658328af9723c44db7e8a8c2a06d18319 from
https://github.com/dalgaaf/puppet-ceph/tree/feature/wip-da-rework-and-simplify)
