### PR TITLE
ceph::osd::journal: prepare separate journal disks

### DIFF
--- a/examples/example-site.pp
+++ b/examples/example-site.pp
@@ -7,7 +7,7 @@ node default {
     # setup some secrets needed for ceph and since we might reuse them on different
     # other nodes, let define them here.
 
-    # puppet-secret generates values for ceph for you ... 
+    # puppet-secret generates values for ceph for you ...
     # https://github.com/TelekomCloud/puppet-secret.git
     $monitor_secret = secret('monitor_secret', {
                   'method' => 'ceph',
@@ -26,9 +26,9 @@ node default {
     $secret_images_value = loadyaml('/secrets/shared/images')
 
     # As alternative use e.g. the following variables and fill it with values from 'ceph-authtool --gen-print-key':
-    # $monitor_secret_value      = 
-    # $client_admin_secret_value = 
-    # $secret_images_value       = 
+    # $monitor_secret_value      =
+    # $client_admin_secret_value =
+    # $secret_images_value       =
 }
 
 ######################## CEPH pseudo NODES ###########################
@@ -74,23 +74,23 @@ node 'cephosd' inherits cephconf {
     cluster_address     => $::ipaddress_eth3,
   }
 
-  # I hope that works for you ... we use that slightly different since we use our 
+  # I hope that works for you ... we use that slightly different since we use our
   # puppet-dmcrypt module here to setup crypted disks and call then ceph::osd::device
   # You can find puppet-dmcrypt here as soon as I find the time to push it:
-  #  https://github.com/TelekomCloud/puppet-dmcrypt 
-  ceph::osd::device { "/dev/sdb":
+  #  https://github.com/TelekomCloud/puppet-dmcrypt
+  ceph::osd::device { '/dev/sdb':
     partition_device    => false,
   }
-  ceph::osd::device { "/dev/sdc":
+  ceph::osd::device { '/dev/sdc':
     partition_device    => false,
   }
-  ceph::osd::device { "/dev/sdd":
+  ceph::osd::device { '/dev/sdd':
     partition_device    => false,
   }
 
   Class['ceph::package']
-   -> Class['ceph::conf']
-   -> Class['ceph::osd']
+    -> Class['ceph::conf']
+    -> Class['ceph::osd']
 }
 
 ######################## CEPH real NODES ###########################
@@ -125,9 +125,9 @@ node /cephmon1/ inherits cephmon {
 }
 
 node /cephmon[2-3]/ inherits cephmon {
-   # NOTHING SPECIAL TO DO HERE
+  # NOTHING SPECIAL TO DO HERE
 }
 
 node /cephosd[1-3]/ inherits cephosd {
-   # NOTHING SPECIAL TO DO HERE
+  # NOTHING SPECIAL TO DO HERE
 }

--- a/manifests/conf/osd.pp
+++ b/manifests/conf/osd.pp
@@ -2,7 +2,14 @@ define ceph::conf::osd (
   $device,
   $cluster_addr = undef,
   $public_addr  = undef,
+  $journal = undef,
 ) {
+
+  if $journal {
+    $journal_real = regsubst($journal, '\$id', $name)
+  } else {
+    $journal_real = undef
+  }
 
   concat::fragment { "ceph-osd-${name}.conf":
     target  => '/etc/ceph/ceph.conf',

--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -9,6 +9,9 @@
 #  Optional. Boolean (true or false).
 #  Defaults to 'false.'
 #
+# [*journal*] path to place the journal
+#  Optional. Defaults to undef.
+#
 # == Dependencies
 #
 # ceph::osd need to be called for the node beforehand. The
@@ -26,6 +29,7 @@
 
 define ceph::osd::device (
   $partition_device = true,
+  $journal          = undef,
 ) {
 
   include ceph::osd
@@ -116,6 +120,7 @@ define ceph::osd::device (
         device       => $dev_path,
         cluster_addr => $::ceph::osd::cluster_address,
         public_addr  => $::ceph::osd::public_address,
+        journal      => $journal,
       }
 
       $osd_data = regsubst($::ceph::conf::osd_data, '\$id', $osd_id)

--- a/manifests/osd/journal.pp
+++ b/manifests/osd/journal.pp
@@ -1,0 +1,59 @@
+# Manages  a ceph osd journal disk
+#
+# We reuse the same mkfs and mount options as for the
+# the OSD disks.
+#
+# == Name
+# the resource name is the full path to the device to be used.
+#
+# == Parameters
+#
+# [*mount_point*] the path the disk mount to
+#  Optional. If not set the disks isn't mounted
+#
+# == Dependencies
+#
+# == Authors
+#
+#  Danny Al-Gaaf <danny.al-gaaf@bisect.de>
+#
+# == Copyright
+#
+# Copyright 2013 Deutsche Telekom AG
+#
+
+define ceph::osd::journal (
+  $mount_point = undef,
+) {
+
+  $dev_path = $name
+  $devname = regsubst($name, '/dev/', '')
+
+  ensure_packages (['ceph'])
+
+  # TODO: add other file systems ... otherwise fail!
+  if $::ceph::conf::osd_mkfs_type == 'xfs' {
+    exec { "mkfs_${devname}":
+      command => "mkfs.xfs ${::ceph::conf::osd_mkfs_options} ${dev_path}",
+      unless  => "xfs_admin -l ${dev_path}",
+      require => [Package['xfsprogs']],
+    }
+  }
+
+  if $mount_point {
+    file { $mount_point:
+      ensure  => directory,
+      require => Package['ceph'],
+    }
+
+    mount { $mount_point:
+      ensure  => mounted,
+      device  => $dev_path,
+      atboot  => true,
+      fstype  => $::ceph::conf::osd_mkfs_type,
+      options => $::ceph::conf::osd_mount_options,
+      pass    => 2,
+      require => [ Exec["mkfs_${devname}"], File[$mount_point] ],
+    }
+  }
+}

--- a/spec/defines/ceph_key_spec.rb
+++ b/spec/defines/ceph_key_spec.rb
@@ -6,6 +6,10 @@ describe 'ceph::key' do
     'client.dummy'
   end
 
+  let :facts do 
+    { :concat_basedir => '/var/lib/puppet/concat' }
+  end
+
   describe 'with default parameters' do
     it { expect { should raise_error(Puppet::Error) } }
   end

--- a/templates/ceph.conf-osd.erb
+++ b/templates/ceph.conf-osd.erb
@@ -7,4 +7,7 @@
 <% if @public_addr -%>
    public addr = <%= @public_addr %>
 <% end -%>
+<% if @journal_real -%>
+   osd journal = <%= @journal_real %>
+<% end -%>
 

--- a/templates/ceph.conf.erb
+++ b/templates/ceph.conf.erb
@@ -55,7 +55,9 @@
   osd journal size = <%= @journal_size_mb %>
   filestore flusher = false
   osd data = <%= @osd_data %>
+<% if @osd_journal_real -%>
   osd journal = <%= @osd_journal_real %>
+<% end -%>
   osd mkfs type = <%= @osd_mkfs_type %>
 <% if @osd_mkfs_options && @osd_mkfs_type -%>
   osd mkfs options <%= @osd_mkfs_type %> = <%= @osd_mkfs_options %>


### PR DESCRIPTION
Add support for separate journal disks, format the disk and
mount the disk on request. The disk gets formated and mounted
with the same options as the OSD disks.

Signed-off-by: Danny Al-Gaaf d.al-gaaf@telekom.de
