### PR TITLE
ceph crush osd set does not create a device if it does not exist

### DIFF
--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -156,7 +156,14 @@ define ceph::osd::device (
         require => Exec["ceph-osd-mkfs-${osd_id}"],
       }
 
-      exec { "ceph-osd-crush-${osd_id}":
+      exec { "ceph-osd-crush-add-${osd_id}":
+        command => "ceph osd crush add ${osd_id} 1 root=default host=${::hostname}",
+        onlyif  => "ceph osd dump |grep -q 'new ${blkid}'",
+        before  => Exec["ceph-osd-crush-set-${osd_id}"],
+        require => Exec["ceph-osd-register-${osd_id}"],
+      }
+
+      exec { "ceph-osd-crush-set-${osd_id}":
         command => "ceph osd crush set ${osd_id} 1 root=default host=${::hostname}",
         require => Exec["ceph-osd-register-${osd_id}"],
       }
@@ -167,7 +174,7 @@ define ceph::osd::device (
         start     => "service ceph start osd.${osd_id}",
         stop      => "service ceph stop osd.${osd_id}",
         status    => "service ceph status osd.${osd_id}",
-        require   => Exec["ceph-osd-crush-${osd_id}"],
+        require   => Exec["ceph-osd-crush-set-${osd_id}"],
         subscribe => Concat['/etc/ceph/ceph.conf'],
       }
 

--- a/spec/defines/ceph_osd_device_spec.rb
+++ b/spec/defines/ceph_osd_device_spec.rb
@@ -118,7 +118,14 @@ class { 'ceph::osd':
         'require' => 'Exec[ceph-osd-mkfs-56]'
       ) }
 
-      it { should contain_exec('ceph-osd-crush-56').with(
+      it { should contain_exec('ceph-osd-crush-add-56').with(
+        'command' => 'ceph osd crush add 56 1 root=default host=dummy-host',
+        'onlyif'  => "ceph osd dump |grep -q 'new dummy-uuid-1234'",
+        'before'  => 'Exec[ceph-osd-crush-set-56]',
+        'require' => 'Exec[ceph-osd-register-56]'
+      ) }
+
+      it { should contain_exec('ceph-osd-crush-set-56').with(
         'command' => 'ceph osd crush set 56 1 root=default host=dummy-host',
         'require' => 'Exec[ceph-osd-register-56]'
       ) }
@@ -128,7 +135,7 @@ class { 'ceph::osd':
         'start'     => 'service ceph start osd.56',
         'stop'      => 'service ceph stop osd.56',
         'status'    => 'service ceph status osd.56',
-        'require'   => 'Exec[ceph-osd-crush-56]',
+        'require'   => 'Exec[ceph-osd-crush-set-56]',
         'subscribe' => 'Concat[/etc/ceph/ceph.conf]'
       ) }
     end


### PR DESCRIPTION
Introduced "ceph osd crush add" to add a device to the crush map if
it does not yet exist, before running "ceph osd crush set".

The behavior of "ceph osd crush set" changed in Ceph Emperor, it
will not create the device automatically if it does not exist anymore.
See release notes:
http://ceph.com/docs/master/release-notes/#v0-72-emperor

I've tested this fix on my own continuous integration setup and it
works well on both Dumpling and Emperor - I am currently unable to
test it against Cuttlefish but it should also work.
