### PR TITLE
ceph::osd::journal: basic support for non-xfs journal disks

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -67,6 +67,9 @@
 # [*osd_journal*] The path to the OSD’s journal.
 #   Optional. Absolute path.
 #
+# [*osd_journal_dio*] Wether the journal should be written with direct IO.
+#   Optional. Defaults to 'true'.
+#
 # [*osd_mkfs_type*] Type of the OSD filesystem.
 #   Optional. Defaults to 'xfs'.
 #
@@ -117,6 +120,7 @@ class ceph::conf (
   $mon_init_members        = undef,
   $osd_data                = '/var/lib/ceph/osd/osd.$id',
   $osd_journal             = undef,
+  $osd_journal_dio         = true,
   $osd_mkfs_type           = 'xfs',
   $osd_mkfs_options        = '-f',
   $osd_mount_options       = 'rw,noatime,inode64',

--- a/templates/ceph.conf.erb
+++ b/templates/ceph.conf.erb
@@ -53,6 +53,7 @@
 
 [osd]
   osd journal size = <%= @journal_size_mb %>
+  journal dio = <%= @osd_journal_dio %>
   filestore flusher = false
   osd data = <%= @osd_data %>
 <% if @osd_journal_real -%>


### PR DESCRIPTION
Add mkfs and mount options to use other filesystems for the
journal disks as e.g. tmpfs. This should support now xfs and
tmpfs.

Feature: SMBCAP-3955

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
