### PR TITLE
Make logging of radosgw optional

### DIFF
--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -33,11 +33,15 @@
 # [*keytone_token_cache_size*] Amount of tokens to keep in cache
 #   Optional. Defaults to '10'
 #
-# [*keystone_revocation_interval*] Number of seconds before checking revoked tickets
+# [*keystone_revocation_interval*] Number of seconds before checking
+#                                  revoked tickets
 #   Optional. Defaults to '60'
 #
 # [*nss_db_path*] Path to the nss db
 #   Optional. Defaults to '/var/lib/ceph/nss'
+#
+# [*debug_log*] Activates radosgw logging
+#   Optional. Default is false.
 #
 # == ToDo
 #
@@ -66,12 +70,13 @@ class ceph::rgw (
   $keystone_accepted_roles      = '_member_, Member, admin, swiftoperator',
   $keystone_token_cache_size    = 10,
   $keystone_revocation_interval = 60,
-  $nss_db_path                  = '/var/lib/ceph/nss'
+  $nss_db_path                  = '/var/lib/ceph/nss',
+  $debug_log                    = false
 ) {
   ensure_packages( [ 'radosgw', 'ceph-common', 'ceph' ] )
 
   if $keystone and !$keystone_url {
-    fail("Keystone integration activated but keystone_url is not set")
+    fail('Keystone integration activated but keystone_url is not set')
   }
 
   file { $::ceph::rgw::rgw_data:

--- a/templates/ceph.conf-rgw.erb
+++ b/templates/ceph.conf-rgw.erb
@@ -1,11 +1,16 @@
 [client.radosgw.gateway]
   # Need this parameter for the default apache2 packages
   rgw print continue = false
-
+  
+<% if @debug_log -%>
   rgw enable usage log = true
   rgw enable ops log = true
   rgw usage log tick interval = 30
   rgw usage log flush threshold = 1024
+<% else -%>
+  debug rgw = 0/5
+<% end -%>
+
   host = <%= @hostname %>
   keyring = <%= @rgw_data %>/keyring.rgw
   rgw socket path = /tmp/radosgw.sock


### PR DESCRIPTION
For production environments ops and usage logs are deactivated to improve
the overall perfomance. A new parameter is introduced to switch the logs
on again.

Signed-off-by: Marc Koderer m.koderer@telekom.de
