### PR TITLE
conf.pp: add noexec to default mount options

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -123,7 +123,7 @@ class ceph::conf (
   $osd_journal_dio         = true,
   $osd_mkfs_type           = 'xfs',
   $osd_mkfs_options        = '-f -i size=2048 -n size=64k',
-  $osd_mount_options       = 'rw,noatime,inode64,nobootwait,logbsize=256k,delaylog',
+  $osd_mount_options       = 'rw,noatime,inode64,nobootwait,noexec,logbsize=256k,delaylog',
   $mds_activate            = true,
   $mds_data                = '/var/lib/ceph/mds/mds.$id'
 ) {


### PR DESCRIPTION
By default prevent exectution of binaries on the OSD disks.
Usually there is no need to exec anything on these disks and
this also fix issues with hardening by preventing the scripts
to run find on OSD disks and subsequently filling up memory
and caches due to high number of files on these disks.

Fixes: SMBCAP-4597

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
